### PR TITLE
chore(core-java): include ditributionManagement tag

### DIFF
--- a/core-java/pom.xml
+++ b/core-java/pom.xml
@@ -27,4 +27,11 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub u-n-l Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/u-n-l/core-java</url>
+        </repository>
+    </distributionManagement>
 </project>


### PR DESCRIPTION
According to the doc ( 
https://docs.github.com/en/packages/guides/configuring-apache-maven-for-use-with-github-packages, https://maven.apache.org/pom.html#Distribution_Management) , we have to add this distributionManagement element in the pom.file 


> Edit the distributionManagement element of the pom.xml file located in your package directory, replacing OWNER with the name of the user or organization account that owns the repository and REPOSITORY with the name of the repository containing your project.
> 
> <distributionManagement>
>    <repository>
>      <id>github</id>
>      <name>GitHub OWNER Apache Maven Packages</name>
>      <url>https://maven.pkg.github.com/OWNER/REPOSITORY</url>
>    </repository>
> </distributionManagement>
